### PR TITLE
FEATURE: Make dictionaries replaceable to eventually enable klingon language support

### DIFF
--- a/Classes/Domain/DictionaryProviderInterface.php
+++ b/Classes/Domain/DictionaryProviderInterface.php
@@ -13,4 +13,6 @@ interface DictionaryProviderInterface
     public function provideWord(int $index): string;
 
     public function provideMaxWordIndex(): int;
+
+    public function provideSentenceSeparator(): string;
 }

--- a/Classes/Domain/PredictableRandomTextGenerator.php
+++ b/Classes/Domain/PredictableRandomTextGenerator.php
@@ -68,13 +68,13 @@ class PredictableRandomTextGenerator
         $targetTotalLength = $this->randomNumber($minTotalLength, $maxTotalLength);
 
         $firstWords = $this->generateWords($minSentenceLength, $maxSentenceLength);
-        $firstSentence = implode(' ', $firstWords) . '.';
+        $firstSentence = implode(' ', $firstWords) . $this->dictionaryProvider->provideSentenceSeparator();
         $currentLength = strlen($firstSentence);
         $sentences = [$firstSentence];
 
         while (true) {
             $words = $this->generateWords($minSentenceLength, $maxSentenceLength);
-            $nextSentence = implode(' ', $words) . '.';
+            $nextSentence = implode(' ', $words) . $this->dictionaryProvider->provideSentenceSeparator();
             $nextLength = $currentLength + 1 + strlen($nextSentence);
 
             if ($nextLength > $maxTotalLength || $currentLength > $targetTotalLength) {

--- a/Classes/Domain/PseudoLatinDictionaryProvider.php
+++ b/Classes/Domain/PseudoLatinDictionaryProvider.php
@@ -100,4 +100,9 @@ class PseudoLatinDictionaryProvider implements DictionaryProviderInterface
     {
         return $this->wordNumber;
     }
+
+    public function provideSentenceSeparator(): string
+    {
+        return '.';
+    }
 }

--- a/Classes/FusionObjects/LineImplementation.php
+++ b/Classes/FusionObjects/LineImplementation.php
@@ -14,7 +14,7 @@ class LineImplementation extends BaseFusionObject
         $seed = crc32($this->path . ($this->fusionValue('seed') ?: ''));
 
         $generator = new PredictableRandomTextGenerator(
-            $this->dictionaryProvider,
+            $this->resolveDictionaryProvider(),
             $seed
         );
 

--- a/Classes/FusionObjects/TextImplementation.php
+++ b/Classes/FusionObjects/TextImplementation.php
@@ -14,7 +14,7 @@ class TextImplementation extends BaseFusionObject
         $seed = crc32($this->path . ($this->fusionValue('seed') ?: ''));
 
         $generator = new PredictableRandomTextGenerator(
-            $this->dictionaryProvider,
+            $this->resolveDictionaryProvider(),
             $seed
         );
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,3 +3,9 @@ Neos:
     fusion:
       autoInclude:
         Sitegeist.ChitChat: true
+
+Sitegeist:
+  ChitChat:
+    dictionaries:
+      default: 'Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider'
+

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The base prototypes `Text` and `Line` will create text without block formatting.
 
 Properties:
 
+- `dictionary` (string|`default`) the name of the dictionaries as configured in the settings
 - `seed` (string|null) the source of randomness in addition to the fusion path
 - `length` (int|100 bzw. 500) the maximal length the text should have
 - `variance` (float|0.5) the deviation in length that is allowed 
@@ -133,6 +134,28 @@ property `number` allows to specify how many items are to be generated.
 Additional properties:
 
 - `number` (int|5) the number of items to generate
+
+## Replacing the dictionary or "how to speak klingon"
+
+To implement custom dictionaries you can provide alternate implementations of the
+interface `\Sitegeist\ChitChat\Domain\DictionaryProviderInterface`. 
+ 
+The dictionaries are registered via Setting.yaml:
+
+```yaml
+Sitegeist:
+  ChitChat:
+    dictionaries:
+      klingon: 'Vendor\Example\KlingonDictionaryProvider'
+```
+
+And can later be used like this:
+
+```neosfusion
+text = Sitegeist.ChitChat:Text {
+  dictionary = 'klingon'
+} 
+```
 
 ## Contribution
 

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,6 +1,7 @@
 prototype(Sitegeist.ChitChat:Text) {
   @class = "Sitegeist\\ChitChat\\FusionObjects\\TextImplementation"
   seed = null
+  dictionary = 'default'
 
   length = 500
   variance = 0.5
@@ -13,6 +14,7 @@ prototype(Sitegeist.ChitChat:Text) {
 prototype(Sitegeist.ChitChat:Line) {
   @class = "Sitegeist\\ChitChat\\FusionObjects\\LineImplementation"
   seed = null
+  dictionary = 'default'
 
   length = 100
   variance = 0.5


### PR DESCRIPTION
To implement custom dictionaries you can provide alternate implementations of the interface `\Sitegeist\ChitChat\Domain\DictionaryProviderInterface`.

The dictionaries are registered via Setting.yaml:

```yaml
Sitegeist:
  ChitChat:
    dictionaries:
      klingon: 'Vendor\Example\KlingonDictionaryProvider'
```

And can later be used like this:

```neosfusion
text = Sitegeist.ChitChat:Text {
  dictionary = 'klingon'
}
```