### PR TITLE
BUGFIX: Handle variance correctly

### DIFF
--- a/Classes/FusionObjects/LineImplementation.php
+++ b/Classes/FusionObjects/LineImplementation.php
@@ -19,7 +19,7 @@ class LineImplementation extends BaseFusionObject
         );
 
         $maxLength = $this->getLength();
-        $minLength = (int) ($maxLength * $this->getVariance());
+        $minLength = (int) round($maxLength - $this->getVariance() * $maxLength);
 
         return $generator->applyFormatting(
             $generator->generateLine($minLength, $maxLength),

--- a/Classes/FusionObjects/TextImplementation.php
+++ b/Classes/FusionObjects/TextImplementation.php
@@ -19,7 +19,7 @@ class TextImplementation extends BaseFusionObject
         );
 
         $maxLength = $this->getLength();
-        $minLength = (int) ($maxLength * $this->getVariance());
+        $minLength = (int) round($maxLength - $this->getVariance() * $maxLength);
 
         return $generator->applyFormatting(
             $generator->generateText($minLength, $maxLength),

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Properties:
 - `dictionary` (string|`default`) the name of the dictionaries as configured in the settings
 - `seed` (string|null) the source of randomness in addition to the fusion path
 - `length` (int|100 bzw. 500) the maximal length the text should have
-- `variance` (float|0.5) the deviation in length that is allowed 
+- `variance` (float|0.5) the factor the actual length can be smaller than the configured `length`. 
 - `link` (bool|false) add links to some items `<a href="#">...</s>`
 - `strong` (bool|false) make some items bold `<strong>...</strong>`
 - `em` (bool|false) emphasize some items `<em>...</em>`


### PR DESCRIPTION
Before variance was used as a factor that was multiplied with length to generate the minimal length. This is confusing and hard to get. With this change variance is the factor that describes the amount the length can be lower than specified.