### PR TITLE
Feature: Add probability modes `predictable` and `random`

### DIFF
--- a/Classes/Domain/PredictableProbabilityProvider.php
+++ b/Classes/Domain/PredictableProbabilityProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\ChitChat\Domain;
+
+class PredictableProbabilityProvider implements ProbabilityProviderInterface
+{
+    protected int $seed = 0;
+    public function initialize(int $seed): void
+    {
+        $this->seed = $seed;
+    }
+
+    public function provideNumber(int $min, int $max): int
+    {
+        mt_srand($this->seed);
+        $result = mt_rand($min, $max);
+        $this->seed = mt_rand(0, getrandmax());
+        return $result;
+    }
+}

--- a/Classes/Domain/PredictableRandomTextGenerator.php
+++ b/Classes/Domain/PredictableRandomTextGenerator.php
@@ -8,16 +8,13 @@ class PredictableRandomTextGenerator
 {
     public function __construct(
         protected DictionaryProviderInterface $dictionaryProvider,
-        protected int $seed = 0
+        protected ProbabilityProviderInterface $probabilityProvider
     ) {
     }
 
     protected function randomNumber(int $min, int $max): int
     {
-        mt_srand($this->seed);
-        $result = mt_rand($min, $max);
-        $this->seed = mt_rand(0, getrandmax());
-        return $result;
+        return $this->probabilityProvider->provideNumber($min, $max);
     }
 
     public function applyFormatting(string $text, bool $link = false, bool $strong = false, bool $em = false): string

--- a/Classes/Domain/ProbabilityProviderInterface.php
+++ b/Classes/Domain/ProbabilityProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sitegeist\ChitChat\Domain;
+
+interface ProbabilityProviderInterface
+{
+    public function initialize(int $seed): void;
+
+    public function provideNumber(int $min, int $max): int;
+}

--- a/Classes/Domain/RandomProbabilityProvider.php
+++ b/Classes/Domain/RandomProbabilityProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\ChitChat\Domain;
+
+class RandomProbabilityProvider implements ProbabilityProviderInterface
+{
+    public function initialize(int $seed): void
+    {
+        // ignore since random
+    }
+
+    public function provideNumber(int $min, int $max): int
+    {
+        return random_int($min, $max);
+    }
+}

--- a/Classes/FusionObjects/BaseFusionObject.php
+++ b/Classes/FusionObjects/BaseFusionObject.php
@@ -8,6 +8,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Sitegeist\ChitChat\Domain\DictionaryProviderInterface;
+use Sitegeist\ChitChat\Domain\ProbabilityProviderInterface;
 use Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider;
 
 abstract class BaseFusionObject extends AbstractFusionObject
@@ -21,10 +22,23 @@ abstract class BaseFusionObject extends AbstractFusionObject
     #[Flow\InjectConfiguration(path:'dictionaries')]
     protected array $dictionariesConfiguration;
 
+    /**
+     * @var array<string,string>
+     */
+    #[Flow\InjectConfiguration(path:'probablility')]
+    protected array $probalilityConfiguration;
+
+    /**
+     * @var array<string,string>
+     */
+    #[Flow\InjectConfiguration(path:'defaults')]
+    protected array $defaultsConfiguration;
+
     public function resolveDictionaryProvider(): DictionaryProviderInterface
     {
-        $dictionary = $this->fusionValue('dictionary');
+        $dictionary = $this->fusionValue('dictionary') ?: $this->defaultsConfiguration['dictionary'] ?? null;
         $dictionaryProvider = null;
+
         if (
             is_string($dictionary)
             && array_key_exists($dictionary, $this->dictionariesConfiguration)
@@ -35,7 +49,26 @@ abstract class BaseFusionObject extends AbstractFusionObject
         if ($dictionaryProvider instanceof DictionaryProviderInterface) {
             return $dictionaryProvider;
         } else {
-            throw new \Exception('missing dictionary');
+            throw new \Exception('missing dictionary provider');
+        }
+    }
+
+    public function resolveProbablityProvider(): ProbabilityProviderInterface
+    {
+        $probability = $this->fusionValue('probability') ?: $this->defaultsConfiguration['probability'] ?? null;
+        $probabilityProvider = null;
+
+        if (
+            is_string($probability)
+            && array_key_exists($probability, $this->probalilityConfiguration)
+            && $this->objectManager->has($this->probalilityConfiguration[$probability])
+        ) {
+            $probabilityProvider = $this->objectManager->get($this->probalilityConfiguration[$probability]);
+        }
+        if ($probabilityProvider instanceof ProbabilityProviderInterface) {
+            return $probabilityProvider;
+        } else {
+            throw new \Exception('missing probability provider');
         }
     }
 

--- a/Classes/FusionObjects/LineImplementation.php
+++ b/Classes/FusionObjects/LineImplementation.php
@@ -13,9 +13,14 @@ class LineImplementation extends BaseFusionObject
     {
         $seed = crc32($this->path . ($this->fusionValue('seed') ?: ''));
 
+        $probabilityProvider = $this->resolveProbablityProvider();
+        $probabilityProvider->initialize($seed);
+
+        $dictionaryProvider = $this->resolveDictionaryProvider();
+
         $generator = new PredictableRandomTextGenerator(
-            $this->resolveDictionaryProvider(),
-            $seed
+            $dictionaryProvider,
+            $probabilityProvider
         );
 
         $maxLength = $this->getLength();

--- a/Classes/FusionObjects/NumberImplementation.php
+++ b/Classes/FusionObjects/NumberImplementation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\ChitChat\FusionObjects;
+
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\ChitChat\Domain\PredictableRandomTextGenerator;
+
+class NumberImplementation extends BaseFusionObject
+{
+    public function evaluate(): int
+    {
+        $seed = crc32($this->path . ($this->fusionValue('seed') ?: ''));
+
+        $probabilityProvider = $this->resolveProbablityProvider();
+        $probabilityProvider->initialize($seed);
+
+        $min = $this->fusionValue('min');
+        $max = $this->fusionValue('max');
+
+        if (!is_scalar($min)) {
+            throw new \InvalidArgumentException("min requires and integer");
+        }
+        if (!is_scalar($max)) {
+            throw new \InvalidArgumentException("max requires and integer");
+        }
+
+        return $probabilityProvider->provideNumber((int) $min, (int) $max);
+    }
+}

--- a/Classes/FusionObjects/TextImplementation.php
+++ b/Classes/FusionObjects/TextImplementation.php
@@ -13,9 +13,14 @@ class TextImplementation extends BaseFusionObject
     {
         $seed = crc32($this->path . ($this->fusionValue('seed') ?: ''));
 
+        $probabilityProvider = $this->resolveProbablityProvider();
+        $probabilityProvider->initialize($seed);
+
+        $dictionaryProvider = $this->resolveDictionaryProvider();
+
         $generator = new PredictableRandomTextGenerator(
-            $this->resolveDictionaryProvider(),
-            $seed
+            $dictionaryProvider,
+            $probabilityProvider
         );
 
         $maxLength = $this->getLength();

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,18 @@ Neos:
 
 Sitegeist:
   ChitChat:
+
+    # the dictionary and probability to use if nothing else is specified
+    defaults:
+      dictionary: pseudoLatin
+      probability: predictable
+
+    # providers for random numbers
+    probablility:
+      predictable: 'Sitegeist\ChitChat\Domain\PredictableProbabilityProvider'
+      random: 'Sitegeist\ChitChat\Domain\RandomProbabilityProvider'
+
+    # dictionaries
     dictionaries:
-      default: 'Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider'
+      pseudoLatin: 'Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider'
 

--- a/README.md
+++ b/README.md
@@ -96,20 +96,31 @@ prototype(Sitegeist.ChitChat:TextExample) < prototype(Neos.Fusion:Component) {
 
 ### Base Prototypes
 
-The base prototypes `Text` and `Line` will create text without block formatting.   
+The base prototypes `Text` and `Line` will create text without block formatting whule  
+`Number` creates integer numbers.
 
 - `Sitegeist.ChitChat:Text`:  (string) long textblock containing multiple sentences
 - `Sitegeist.ChitChat:Line`:  (string) short textblock without
+- `Sitegeist.ChitChat:Number`: (int)
 
-Properties:
+All prototypes have the properties:
 
-- `dictionary` (string|`default`) the name of the dictionaries as configured in the settings
+- `probability` (string|null) the name of the probability as configured in the settings.
 - `seed` (string|null) the source of randomness in addition to the fusion path
+
+The `Text` and `Line` prototypes support in addition:
+
+- `dictionary` (string|null) the name of the dictionaries as configured in the settings
 - `length` (int|100 bzw. 500) the maximal length the text should have
 - `variance` (float|0.5) the deviation in length that is allowed 
 - `link` (bool|false) add links to some items `<a href="#">...</s>`
 - `strong` (bool|false) make some items bold `<strong>...</strong>`
 - `em` (bool|false) emphasize some items `<em>...</em>`
+
+The `Number` prototype supports in addition:
+
+- `min` (int|0) the minimal number to create
+- `max` (int|100) the maximal number to create
 
 ### Textblock Fusion Prototypes
 
@@ -133,7 +144,39 @@ property `number` allows to specify how many items are to be generated.
 
 Additional properties:
 
-- `number` (int|5) the number of items to generate
+- `number` (int|5) the number of items to generate ... defaults to a random number between 5 and 10
+
+## Configuration
+
+The configuration allows to configure alternate implementations for  
+
+```yaml
+Sitegeist:
+  ChitChat:
+
+    # the dictionary and probability to use if nothing else is specified
+    defaults:
+      dictionary: pseudoLatin
+      probability: predictable
+
+    # providers for random numbers
+    probablility:
+      predictable: 'Sitegeist\ChitChat\Domain\PredictableProbabilityProvider'
+      random: 'Sitegeist\ChitChat\Domain\RandomProbabilityProvider'
+
+    # dictionaries
+    dictionaries:
+      pseudoLatin: 'Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider'
+```
+
+## Randomness vs predictability
+
+While predictable text generation is important for stable tests and therefore is the default.
+The testing of frontend prototypes sometimes benefits from completely random texts that are regenerated
+on every call.
+
+To allow this the probability mode can be configured via setting `Setting` or fusion path `probability`.
+By default the modes `random` and `predictable` are available.
 
 ## Replacing the dictionary or "how to speak klingon"
 

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,7 +1,8 @@
 prototype(Sitegeist.ChitChat:Text) {
   @class = "Sitegeist\\ChitChat\\FusionObjects\\TextImplementation"
   seed = null
-  dictionary = 'default'
+  dictionary = null
+  probability = null
 
   length = 500
   variance = 0.5
@@ -14,7 +15,8 @@ prototype(Sitegeist.ChitChat:Text) {
 prototype(Sitegeist.ChitChat:Line) {
   @class = "Sitegeist\\ChitChat\\FusionObjects\\LineImplementation"
   seed = null
-  dictionary = 'default'
+  dictionary = null
+  probability = null
 
   length = 100
   variance = 0.5
@@ -22,6 +24,15 @@ prototype(Sitegeist.ChitChat:Line) {
   link = false
   strong = false
   em = false
+}
+
+prototype(Sitegeist.ChitChat:Number) {
+  @class = "Sitegeist\\ChitChat\\FusionObjects\\NumberImplementation"
+  seed = null
+  probability = null
+
+  min = 100
+  max = 0.5
 }
 
 prototype(Sitegeist.ChitChat:H1) < prototype(Neos.Fusion:Component) {
@@ -70,7 +81,11 @@ prototype(Sitegeist.ChitChat:P) < prototype(Neos.Fusion:Component) {
 
 prototype(Sitegeist.ChitChat:UL) < prototype(Neos.Fusion:Component) {
 
-  number = 5
+  number = Sitegeist.ChitChat:Number {
+    min = 5
+    max = 10
+  }
+
   length = 100
 
   link = true
@@ -88,7 +103,11 @@ prototype(Sitegeist.ChitChat:UL) < prototype(Neos.Fusion:Component) {
 
 prototype(Sitegeist.ChitChat:OL) < prototype(Neos.Fusion:Component) {
 
-  number = 5
+  number = Sitegeist.ChitChat:Number {
+    min = 5
+    max = 10
+  }
+
   length = 100
 
   link = true

--- a/Tests/Unit/PredictableRandomTextGeneratorTest.php
+++ b/Tests/Unit/PredictableRandomTextGeneratorTest.php
@@ -5,26 +5,33 @@ declare(strict_types=1);
 namespace Sitegeist\ChitChat\Tests\Utility;
 
 use PHPUnit\Framework\TestCase;
+use Sitegeist\ChitChat\Domain\DictionaryProviderInterface;
 use Sitegeist\ChitChat\Domain\FormatOption;
+use Sitegeist\ChitChat\Domain\PredictableProbabilityProvider;
 use Sitegeist\ChitChat\Domain\PredictableRandomTextGenerator;
 use Sitegeist\ChitChat\Domain\PredictableTextGenerator;
+use Sitegeist\ChitChat\Domain\ProbabilityProviderInterface;
 use Sitegeist\ChitChat\Domain\PseudoLatinDictionaryProvider;
 use Sitegeist\Noderobis\Utility\ConfigurationUtility;
 
 class PredictableRandomTextGeneratorTest extends TestCase
 {
-    protected $dictionary;
-    public function setUp(): void
-    {
-        $this->dictionary = new PseudoLatinDictionaryProvider();
-    }
 
+
+    public function createTextGeneratorWithSeed(string $seed): PredictableRandomTextGenerator
+    {
+        $dictionaryProvider = new PseudoLatinDictionaryProvider();
+        $probabilityProvider = new PredictableProbabilityProvider();
+        $probabilityProvider->initialize(crc32($seed));
+
+        return new PredictableRandomTextGenerator(
+        $dictionaryProvider,
+        $probabilityProvider
+        );
+    }
     public function testThatLinesThatAreGeneratedMatchTheRequirements (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         for($i = 1; $i < 200; $i ++) {
             $line = $generator->generateLine(50, 150);
@@ -35,20 +42,9 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatSameSeedsYieldIdenticalLines (): void
     {
-        $generator1 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator2 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator3 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('tomatensuppe')
-        );
+        $generator1 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator2 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator3 = $this->createTextGeneratorWithSeed('tomatensuppe');
 
         $text1 = $generator1->generateLine(20, 50);
         $text2 = $generator2->generateLine(20, 50);
@@ -60,10 +56,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatConsecutiveCallsYieldDifferentLines (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         $text1 = $generator->generateLine(20, 50);
         $text2 = $generator->generateLine(20, 50);
@@ -75,10 +68,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatTextThatAreGeneratedMatchTheRequirements (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         for($i = 1; $i < 200; $i ++) {
             $line = $generator->generateText(500, 1500);
@@ -89,10 +79,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatTextsThatAreGeneratedMatchTheRequirements (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         for($i = 1; $i < 200; $i ++) {
             $line = $generator->generateText(200, 500);
@@ -103,20 +90,9 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatSameSeedsYieldIdenticalTexts (): void
     {
-        $generator1 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator2 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator3 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('tomatensuppe')
-        );
+        $generator1 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator2 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator3 = $this->createTextGeneratorWithSeed('tomatensuppe');
 
         $text1 = $generator1->generateText(200, 500);
         $text2 = $generator2->generateText(200, 500);
@@ -128,10 +104,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatConxecutiveCallsYieldDifferentTexts (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         $text1 = $generator->generateText(200, 500);
         $text2 = $generator->generateText(200, 500);
@@ -143,10 +116,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatFormattingsAreApplies (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         $origin = 'Lorem et Himenaeos cras Ridiculus nostra Cras congue Lectus Donec Risus. Adipiscing Dictum viverra commodo Mollis venenatis Phasellus Nam Nunc. Dolor lacinia hac Velit porttitor risus ad Ante ligula habitant.';
 
@@ -174,20 +144,9 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatSameSeedsYieldIdenticalFormatting (): void
     {
-        $generator1 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator2 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
-
-        $generator3 = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('tomatensuppe')
-        );
+        $generator1 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator2 = $this->createTextGeneratorWithSeed('nudelsuppe');
+        $generator3 = $this->createTextGeneratorWithSeed('tomatensuppe');
 
         $text = 'Lorem et Himenaeos cras Ridiculus nostra Cras congue Lectus Donec Risus. Adipiscing Dictum viverra commodo Mollis venenatis Phasellus Nam Nunc. Dolor lacinia hac Velit porttitor risus ad Ante ligula habitant.';
 
@@ -201,10 +160,7 @@ class PredictableRandomTextGeneratorTest extends TestCase
 
     public function testThatConsecutiveCallsYieldDifferentFormatting (): void
     {
-        $generator = new PredictableRandomTextGenerator(
-            $this->dictionary,
-            crc32('nudelsuppe')
-        );
+        $generator = $this->createTextGeneratorWithSeed('nudelsuppe');
 
         $text = 'Lorem et Himenaeos cras Ridiculus nostra Cras congue Lectus Donec Risus. Adipiscing Dictum viverra commodo Mollis venenatis Phasellus Nam Nunc. Dolor lacinia hac Velit porttitor risus ad Ante ligula habitant.';
 


### PR DESCRIPTION
The probability is implemented via probabilty-providers which are registered via setting. A default configuration was added to control the probility-providers and dictionary-providers that are used if nothing else is specified.

In addition the prototype `Sitegeist.ChitChat:Number` was added mainly to randomize the number of items in lists.